### PR TITLE
add permission to GetLifecycleConfiguration 

### DIFF
--- a/base-config-template.yml
+++ b/base-config-template.yml
@@ -58,6 +58,7 @@ s3_config:
                     "s3:GetBucketVersioning",
                     "s3:GetBucketWebsite",
                     "s3:GetEncryptionConfiguration",
+                    "s3:GetLifecycleConfiguration",
                     "s3:ListBucket",
                     "s3:ListBucketMultipartUploads",
                     "s3:ListBucketVersions",

--- a/federalist-config-template.yml
+++ b/federalist-config-template.yml
@@ -57,6 +57,7 @@ s3_config:
                     "s3:GetBucketVersioning",
                     "s3:GetBucketWebsite",
                     "s3:GetEncryptionConfiguration",
+                    "s3:GetLifecycleConfiguration",
                     "s3:ListBucket",
                     "s3:ListBucketMultipartUploads",
                     "s3:ListBucketVersions",

--- a/pages-config-template.yml
+++ b/pages-config-template.yml
@@ -57,6 +57,7 @@ s3_config:
                     "s3:GetBucketVersioning",
                     "s3:GetBucketWebsite",
                     "s3:GetEncryptionConfiguration",
+                    "s3:GetLifecycleConfiguration",
                     "s3:ListBucket",
                     "s3:ListBucketMultipartUploads",
                     "s3:ListBucketVersions",


### PR DESCRIPTION
## Changes proposed in this pull request:

Closes #65 

- Add permission for GetLifecycleConfiguration to IAM user provisioned by broker for accessing bucket. This will allow users to inspect the lifecycle configuration of their brokered buckets

## security considerations

These permissions are only for getting lifecycle configuration, not modifying or deleting it. So there should be no risk to adding this permission