### PR TITLE
cf resource wants string envars

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -86,7 +86,7 @@ jobs:
         AWS_REGION: ((development-aws-region))
         AWS_ACCESS_KEY: ((development-aws-access-key-id))
         AWS_SECRET_ACCESS_KEY: ((development-aws-secret-access-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
   - task: update-broker
     file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
@@ -241,7 +241,7 @@ jobs:
         AWS_REGION: ((staging-aws-region))
         AWS_ACCESS_KEY: ((staging-aws-access-key-id))
         AWS_SECRET_ACCESS_KEY: ((staging-aws-secret-access-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
   - task: update-broker
     file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
@@ -313,7 +313,7 @@ jobs:
         AWS_REGION: ((staging-aws-region))
         AWS_ACCESS_KEY: ((federalist-staging-aws-access-key-id))
         AWS_SECRET_ACCESS_KEY: ((federalist-staging-aws-secret-access-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
   - task: update-broker
     file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
@@ -478,7 +478,7 @@ jobs:
         AWS_REGION: ((production-aws-region))
         AWS_ACCESS_KEY: ((production-aws-access-key-id))
         AWS_SECRET_ACCESS_KEY: ((production-aws-secret-access-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
   - task: update-broker
     file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
@@ -549,7 +549,7 @@ jobs:
         AWS_REGION: ((federalist-production-aws-region))
         AWS_ACCESS_KEY: ((federalist-production-aws-access-key-id))
         AWS_SECRET_ACCESS_KEY: ((federalist-production-aws-secret-access-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
   - task: update-broker
     file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
@@ -613,7 +613,7 @@ jobs:
         AWS_REGION: ((federalist-production-aws-region))
         AWS_ACCESS_KEY: ((federalist-production-aws-access-key-id))
         AWS_SECRET_ACCESS_KEY: ((federalist-production-aws-secret-access-key))
-        AWS_USE_FIPS_ENDPOINT: true
+        AWS_USE_FIPS_ENDPOINT: "true"
   - task: update-broker
     file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- the CF concourse resource requires envars to be strings

## security considerations

- Trigger the broker to use S3 fips endpoints for provisioning
